### PR TITLE
Fixed a bug that prevented demo from running on the CPU.

### DIFF
--- a/demo/inference.py
+++ b/demo/inference.py
@@ -223,7 +223,7 @@ def main():
 
     if cfg.TEST.MODEL_FILE:
         print('=> loading model from {}'.format(cfg.TEST.MODEL_FILE))
-        pose_model.load_state_dict(torch.load(cfg.TEST.MODEL_FILE), strict=False)
+        pose_model.load_state_dict(torch.load(cfg.TEST.MODEL_FILE, map_location=CTX), strict=False)
     else:
         print('expected model defined in config at TEST.MODEL_FILE')
 


### PR DESCRIPTION
I got the following error when I run this program with MBP.

```
RuntimeError: Attempting to deserialize object on a CUDA device but torch.cuda.is_available() is False. If you are running on a CPU-only machine, please use torch.load with map_location=torch.device('cpu') to map your storages to the CPU.
```

This bug is now fixed.