### PR TITLE
Fix loss typo

### DIFF
--- a/lib/core/loss.py
+++ b/lib/core/loss.py
@@ -26,8 +26,8 @@ class JointsMSELoss(nn.Module):
         loss = 0
 
         for idx in range(num_joints):
-            heatmap_pred = heatmaps_pred[idx].squeeze()
-            heatmap_gt = heatmaps_gt[idx].squeeze()
+            heatmap_pred = heatmaps_pred[:, idx].squeeze()
+            heatmap_gt = heatmaps_gt[:, idx].squeeze()
             if self.use_target_weight:
                 loss += 0.5 * self.criterion(
                     heatmap_pred.mul(target_weight[:, idx]),
@@ -66,8 +66,8 @@ class JointsOHKMMSELoss(nn.Module):
 
         loss = []
         for idx in range(num_joints):
-            heatmap_pred = heatmaps_pred[idx].squeeze()
-            heatmap_gt = heatmaps_gt[idx].squeeze()
+            heatmap_pred = heatmaps_pred[:, idx].squeeze()
+            heatmap_gt = heatmaps_gt[:, idx].squeeze()
             if self.use_target_weight:
                 loss.append(0.5 * self.criterion(
                     heatmap_pred.mul(target_weight[:, idx]),


### PR DESCRIPTION
`heatmaps_pred` have shape (batch_size, num_joints, H*W), and idx represents index of num_joints.
But original source code using idx for batch_size dimension.